### PR TITLE
Use mainline archivesspace-client gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "2.6.5"
 
+gem "archivesspace-client"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "devise"
 gem "jbuilder", "~> 2.7"
@@ -17,8 +18,6 @@ gem "simple_form"
 gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "webpacker", "~> 5.0"
-
-gem "archivesspace-client", github: "pulibrary/archivesspace-client", branch: "fix_login"
 
 group :development, :test do
   gem "bixby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: https://github.com/pulibrary/archivesspace-client.git
-  revision: 808b08d66b71025a331f0ba67d84b2b28be5a4ae
-  branch: fix_login
-  specs:
-    archivesspace-client (0.1.5)
-      httparty (= 0.14.0)
-      json (>= 2.0.3)
-      nokogiri (>= 1.6.8.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -75,6 +65,10 @@ GEM
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
+    archivesspace-client (0.1.8)
+      httparty (~> 0.14)
+      json (~> 2.0)
+      nokogiri (~> 1.10)
     ast (2.4.2)
     backport (1.1.2)
     bcrypt (3.1.16)
@@ -128,7 +122,8 @@ GEM
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
     hashie (4.1.0)
-    httparty (0.14.0)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -150,6 +145,9 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
     mini_mime (1.0.3)
     minitest (5.14.4)
     msgpack (1.4.2)
@@ -352,7 +350,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
-  archivesspace-client!
+  archivesspace-client
   bixby
   bootsnap (>= 1.4.4)
   capybara (>= 3.26)
@@ -387,4 +385,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.2.16
+   2.2.19


### PR DESCRIPTION
We were previously using a forked version of this gem in order to get
updated dependencies. Those dependencies have since been fixed
upstream.

Fixes #15 