### PR TITLE
Validate that the entered barcode is valid

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,10 +36,6 @@ Metrics/ModuleLength:
   Exclude:
     - 'spec/support/stub_aspace.rb'
 
-Metrics/ModuleLength:
-  Exclude:
-    - 'spec/support/stub_aspace.rb'
-
 RSpec/DescribeClass:
   Exclude:
     - 'spec/system/**/*'

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -31,6 +31,7 @@ class Batch < ApplicationRecord
   validates :end_box, numericality: { allow_nil: true, greater_than_or_equal_to: ->(batch) { batch.start_box.to_i } }
   validate :call_number_exists_in_aspace
   validate :top_containers_exist_in_aspace
+  validate :first_barcode_valid
   validate :barcodes_not_in_aspace
   has_many :absolute_identifiers, dependent: :destroy
   belongs_to :user
@@ -88,6 +89,11 @@ class Batch < ApplicationRecord
   end
 
   private
+
+  def first_barcode_valid
+    return true if BarcodeService.valid?(first_barcode)
+    errors.add(:first_barcode, "is not valid")
+  end
 
   def call_number_exists_in_aspace
     # Use resource_uri as a cache of its path.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
       post :synchronize
     end
   end
-  resources :batches, only: [:index, :create, :show]
 
   devise_scope :user do
     get "sign_in", to: "devise/sessions#new", as: :new_user_session

--- a/spec/fixtures/aspace/top_containers_barcodes_32101113342718.json
+++ b/spec/fixtures/aspace/top_containers_barcodes_32101113342718.json
@@ -1,0 +1,1 @@
+{"page_size":30,"first_page":1,"last_page":0,"this_page":1,"offset_first":1,"offset_last":0,"total_hits":0,"results":[],"facets":{"facet_queries":{},"facet_fields":{},"facet_dates":{},"facet_ranges":{},"facet_intervals":{}}}

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe Batch, type: :model do
     expect(batch).not_to be_valid
   end
 
+  it "is invalid when the first barcode is invalid" do
+    stub_barcode_search(barcodes: ["32101113342718"])
+    batch = FactoryBot.build(:batch, first_barcode: "32101113342718")
+
+    expect(batch).not_to be_valid
+  end
+
   it "creates abids on save" do
     stub_barcode_search(barcodes: ["32101113344905", "32101113344913"])
     stub_top_container_search(ead_id: "ABID001", repository_id: "4", indicators: 31..32)


### PR DESCRIPTION
- Checks if barcode is valid against Luhn algorithm. Mostly just validating the check digit.
- Removes some superfluous configuration.