### PR TITLE
Add support for barcode-only identifiers.

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -40,6 +40,6 @@ class BatchesController < ApplicationController
   end
 
   def batch_params
-    params.require(:batch).permit(:call_number, :start_box, :end_box, :container_profile_uri, :location_uri, :first_barcode)
+    params.require(:batch).permit(:call_number, :start_box, :end_box, :container_profile_uri, :location_uri, :first_barcode, :generate_abid)
   end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -9,6 +9,12 @@ html, body {
 
 #batch-create {
   border: 1px solid var(--bs-gray);
+  input.boolean {
+    background-color: var(--bs-blue) !important;
+  }
+  label.boolean {
+    color: black !important;
+  }
 }
 
 #welcome {

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -10,6 +10,9 @@ html, body {
 #batch-create {
   border: 1px solid var(--bs-gray);
   input.boolean {
+    background-color: white !important;
+  }
+  input.boolean:checked {
     background-color: var(--bs-blue) !important;
   }
   label.boolean {

--- a/app/models/absolute_identifier.rb
+++ b/app/models/absolute_identifier.rb
@@ -32,16 +32,25 @@ class AbsoluteIdentifier < ApplicationRecord
   scope :synchronized, -> { where(sync_status: "synchronized") }
 
   def full_identifier
+    return if suffix.blank?
     format("#{prefix}-%.6d", suffix)
   end
 
   def set_suffix
-    return if suffix.present?
+    return if suffix.present? || !generate_abid
     self.suffix = highest_identifier + 1
   end
 
   def synchronize
     Synchronizer.new(absolute_identifier: self).sync!
+  end
+
+  def generate_abid
+    if batch
+      batch.generate_abid
+    else
+      true
+    end
   end
 
   private

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -10,6 +10,7 @@
 #  container_profile_uri  :string
 #  end_box                :integer
 #  first_barcode          :string
+#  generate_abid          :boolean          default(TRUE)
 #  location_data          :jsonb
 #  location_uri           :string
 #  resource_uri           :string

--- a/app/services/synchronizer.rb
+++ b/app/services/synchronizer.rb
@@ -13,6 +13,7 @@ class Synchronizer
     end
     top_container.location = absolute_identifier.batch.location_uri
     top_container.container_profile = absolute_identifier.batch.container_profile_uri
+    top_container.barcode = absolute_identifier.barcode
     aspace_client.save_top_container(top_container: top_container)
     absolute_identifier.sync_status = "synchronized"
     absolute_identifier.save

--- a/app/services/synchronizer.rb
+++ b/app/services/synchronizer.rb
@@ -8,7 +8,9 @@ class Synchronizer
   def sync!
     absolute_identifier.sync_status = "synchronizing"
     absolute_identifier.save
-    top_container.indicator = absolute_identifier.full_identifier
+    if absolute_identifier.generate_abid
+      top_container.indicator = absolute_identifier.full_identifier
+    end
     top_container.location = absolute_identifier.batch.location_uri
     top_container.container_profile = absolute_identifier.batch.container_profile_uri
     aspace_client.save_top_container(top_container: top_container)

--- a/app/values/top_container.rb
+++ b/app/values/top_container.rb
@@ -12,6 +12,10 @@ class TopContainer
     source["indicator"] = val
   end
 
+  def barcode=(val)
+    source["barcode"] = val
+  end
+
   def location=(ref)
     source["container_locations"] = [
       {

--- a/app/views/batches/_form.html.erb
+++ b/app/views/batches/_form.html.erb
@@ -26,5 +26,6 @@
           <%= f.input :location_uri, label: "Location", collection: @locations, label_method: :title, value_method: :uri %>
         </div>
       </div>
+      <%= f.input :generate_abid, label: "Generate Absolute Identifier" %>
       <%= f.button :submit, class: 'btn-primary' %>
     <% end %>

--- a/db/migrate/20210609160852_add_generate_abid_to_absolute_identifiers.rb
+++ b/db/migrate/20210609160852_add_generate_abid_to_absolute_identifiers.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddGenerateAbidToAbsoluteIdentifiers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :batches, :generate_abid, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_08_001004) do
+ActiveRecord::Schema.define(version: 2021_06_09_160852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 2021_06_08_001004) do
     t.bigint "user_id"
     t.jsonb "location_data"
     t.jsonb "container_profile_data"
+    t.boolean "generate_abid", default: true
     t.index ["user_id"], name: "index_batches_on_user_id"
   end
 

--- a/spec/models/absolute_identifier_spec.rb
+++ b/spec/models/absolute_identifier_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe AbsoluteIdentifier, type: :model do
           ] }
       ))).to have_been_made
       expect(save_stub.with(body: hash_including({ "indicator" => "B-001556" }))).to have_been_made
+      expect(save_stub.with(body: hash_including({ "barcode" => firestone1.barcode }))).to have_been_made
     end
     it "doesn't synchronize identifier if generate_abid is false" do
       firestone1 = FactoryBot.create(:batch, generate_abid: false).absolute_identifiers.first
@@ -105,6 +106,7 @@ RSpec.describe AbsoluteIdentifier, type: :model do
           ] }
       ))).to have_been_made
       expect(save_stub.with(body: hash_including({ "indicator" => "31" }))).to have_been_made
+      expect(save_stub.with(body: hash_including({ "barcode" => firestone1.barcode }))).to have_been_made
     end
   end
 end

--- a/spec/requests/batches_spec.rb
+++ b/spec/requests/batches_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe BatchesController do
 
       expect(response.body).to have_select "Container profile", with_options: ["Elephant size box"]
       expect(response.body).to have_select "Location", with_options: ["Annex, Annex B [anxb]"]
+      expect(response.body).to have_checked_field "Generate Absolute Identifier"
     end
   end
   context "when not logged in" do


### PR DESCRIPTION
Closes #49 

This also fixes an issue where barcodes weren't synchronizing to top containers.

![Screen Shot 2021-06-09 at 9 32 48 AM](https://user-images.githubusercontent.com/2806645/121394904-adee6280-c906-11eb-92f4-68dd343f5e6c.png)
