### PR TITLE
Create absolute identifiers after_save and in sequence.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,6 +371,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-17
+  x86_64-darwin-18
   x86_64-darwin-19
   x86_64-linux
 

--- a/app/models/absolute_identifier.rb
+++ b/app/models/absolute_identifier.rb
@@ -18,6 +18,7 @@
 #
 # Indexes
 #
+#  absolute_identifiers_uniqueness         (prefix,suffix,pool_identifier) UNIQUE
 #  index_absolute_identifiers_on_batch_id  (batch_id)
 #
 # Foreign Keys

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -40,7 +40,7 @@ class Batch < ApplicationRecord
 
   before_save :cache_location_data
   before_save :cache_container_profile_data
-  before_save :create_absolute_identifiers
+  after_save :create_absolute_identifiers
 
   def location
     @location ||=
@@ -148,14 +148,14 @@ class Batch < ApplicationRecord
   def create_absolute_identifiers
     return unless absolute_identifiers.empty?
     top_containers.each_with_index do |top_container, idx|
-      absolute_identifier = AbsoluteIdentifier.new(
+      AbsoluteIdentifier.create!(
         barcode: barcodes[idx],
         original_box_number: top_container.indicator,
         pool_identifier: pool_identifier,
         prefix: abid_prefix,
-        top_container_uri: top_container.uri
+        top_container_uri: top_container.uri,
+        batch: self
       )
-      absolute_identifiers << absolute_identifier
     end
   end
 

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -148,14 +148,16 @@ class Batch < ApplicationRecord
   def create_absolute_identifiers
     return unless absolute_identifiers.empty?
     top_containers.each_with_index do |top_container, idx|
-      AbsoluteIdentifier.create!(
-        barcode: barcodes[idx],
-        original_box_number: top_container.indicator,
-        pool_identifier: pool_identifier,
-        prefix: abid_prefix,
-        top_container_uri: top_container.uri,
-        batch: self
-      )
+      transaction do
+        AbsoluteIdentifier.create!(
+          barcode: barcodes[idx],
+          original_box_number: top_container.indicator,
+          pool_identifier: pool_identifier,
+          prefix: abid_prefix,
+          top_container_uri: top_container.uri,
+          batch: self
+        )
+      end
     end
   end
 

--- a/db/migrate/20210623231309_add_unique_index.rb
+++ b/db/migrate/20210623231309_add_unique_index.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndex < ActiveRecord::Migration[6.1]
+  def change
+    add_index :absolute_identifiers, [:prefix, :suffix, :pool_identifier], unique: true, name: "absolute_identifiers_uniqueness"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_09_160852) do
+ActiveRecord::Schema.define(version: 2021_06_23_231309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2021_06_09_160852) do
     t.string "barcode"
     t.bigint "batch_id"
     t.index ["batch_id"], name: "index_absolute_identifiers_on_batch_id"
+    t.index ["prefix", "suffix", "pool_identifier"], name: "absolute_identifiers_uniqueness", unique: true
   end
 
   create_table "batches", force: :cascade do |t|


### PR DESCRIPTION
In Staging/Production the callbacks were firing before the transaction was committed, which was making it so it couldn't query the existing state for the next AbID. Instead this makes the batch increment when it's creating AbIDs and adds a unique identifier to ensure that if something goes wrong the database never ends up with two AbIDs with the same identifier.

I could not replicate this in tests - there must be something special about how the test setup handles transactions.

Closes #72