### PR TITLE
Allow abid generation in the presence of object without a suffix

### DIFF
--- a/app/models/absolute_identifier.rb
+++ b/app/models/absolute_identifier.rb
@@ -82,7 +82,7 @@ class AbsoluteIdentifier < ApplicationRecord
   private
 
   def highest_identifier
-    self.class.where(prefix: prefix, pool_identifier: pool_identifier).order(suffix: :desc).pick(:suffix) || last_legacy_identifier
+    self.class.where(prefix: prefix, pool_identifier: pool_identifier).where.not(suffix: nil).order(suffix: :desc).pick(:suffix) || last_legacy_identifier
   end
 
   # The old database ended identifiers for each pool at certain numbers - ensure

--- a/app/services/barcode_service.rb
+++ b/app/services/barcode_service.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
+
+##
+# Given a barcode, be able to get the next one in the sequence. This is coded
+# against the barcodes used specifically at Princeton. Uses Luhn algorithm (*not*
+# codabar algorithm).
 class BarcodeService
   def self.valid?(barcode)
     new(barcode).valid?

--- a/spec/models/absolute_identifier_spec.rb
+++ b/spec/models/absolute_identifier_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe AbsoluteIdentifier, type: :model do
         expect(firestone1.full_identifier).to be_blank
       end
     end
+    context "generate_abid==true AFTER generate_abid==false" do
+      it "does not raise an error" do
+        FactoryBot.create(:batch, first_barcode: "32101113344913").absolute_identifiers.first
+        FactoryBot.create(:batch, generate_abid: false).absolute_identifiers.first
+        expect { FactoryBot.create(:batch, first_barcode: "32101113344921").absolute_identifiers.first }.not_to raise_error
+      end
+    end
   end
 
   describe "#synchronize" do


### PR DESCRIPTION
When an abid model object is created without an abid archival
identifier, its suffix in the database is nil. When we attempt to create
an abid, it has to find the last identifier, and if that identifier is
nil the system cannot determine what number should come next. Therefore,
exclude nil suffix objects from consideration when determining the next
archival identifier.

Co-authored-by: Trey Pendraon <tpendragon@princeton.edu>

Fixes #76 