### PR TITLE
Update staging.rb with new server name

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-server "abid-staging2.princeton.edu", user: "deploy", roles: %w[app db web]
+server "abid-staging2.lib.princeton.edu", user: "deploy", roles: %w[app db web]


### PR DESCRIPTION
We migrated the abid-staging infrastructure to the private IP space, the .lib domain, and the dev load balancers today. This updates the Capistrano config to match.