### PR TITLE
Add an error when log in worked but user info doesn't

### DIFF
--- a/app/services/aspace/client.rb
+++ b/app/services/aspace/client.rb
@@ -37,7 +37,9 @@ module Aspace
     end
 
     def user_info(ref:)
-      get(ref).parsed
+      result = get(ref)
+      return result.parsed if result.status_code == 200
+      raise ArchivesSpace::ConnectionError, "Error getting user info for #{ref}, status: #{result.status_code}, body: #{result.body}"
     end
 
     def find_top_containers(repository_uri:, ead_id:, indicators:)


### PR DESCRIPTION
This helped with debugging for #186; seems like it could be handy again down the line.
