### PR TITLE
Don't update things with renovate for 14 days.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
     "npm",
     "custom.regex"
   ],
+  "minimumReleaseAge": "14 days",
   "packageRules": [
     {
       "matchDatasources": [


### PR DESCRIPTION
Someday we might want to auto-merge updates, in which case we want to
avoid things like dependency pipeline attacks. Giving a two week window
should be plenty of time.

Security patches bypass this requirement.

Documentation: https://docs.renovatebot.com/key-concepts/minimum-release-age/
